### PR TITLE
Remove initialize from ERC721Full

### DIFF
--- a/contracts/token/ERC721/ERC721Full.sol
+++ b/contracts/token/ERC721/ERC721Full.sol
@@ -12,9 +12,5 @@ import "./ERC721Metadata.sol";
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Full is Initializable, ERC721, ERC721Enumerable, ERC721Metadata {
-    function initialize(string memory name, string memory symbol) public initializer {
-      ERC721Metadata.initialize(name, symbol);
-    }
-
     uint256[50] private ______gap;
 }


### PR DESCRIPTION
Following d75ba162 ERC721 should not initialize their parents.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the JS/Solidity linters and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
