### PR TITLE
Comparison with block.timestamp in TimedCrowdSale reduced by a second…

### DIFF
--- a/contracts/crowdsale/validation/TimedCrowdsale.sol
+++ b/contracts/crowdsale/validation/TimedCrowdsale.sol
@@ -38,7 +38,7 @@ contract TimedCrowdsale is Initializable, Crowdsale {
         assert(Crowdsale._hasBeenInitialized());
 
         // solhint-disable-next-line not-rely-on-time
-        require(openingTime >= block.timestamp);
+        require(openingTime >= block.timestamp - 1);
         require(closingTime > openingTime);
 
         _openingTime = openingTime;


### PR DESCRIPTION
… to fix issues with Ganache for testing

As discussed in [this issue](https://github.com/trufflesuite/truffle/issues/2092), TimedCrowdSale will break sometimes in tests on local development network ran by Ganache due to the fact, that `time.latest()` is a second behind the `block.timestamp`. This is happening not always, but very often. 

This is the root cause why particular tests from OpenZepplin-eth won't run on all my developer machines and even in my own tests to own contracts, where I borrowed these specific lines from TimedCrowdSake:

`require(openingTime >= block.timestamp);`

There is an arbitrary count of test-runs, where these tests are going through and where they'll fail.

But when we subtract one second, everything works fine:

`require(openingTime >= block.timestamp - 1);`

I think, this might not be an issue in production deployment on Mainnet, because it is just a single second and won't hurt. But it will safe many development hours and even those from external Auditers and improve ours and their work on the particular parts of our contracts. Since truffle is not capable of mentioning the real error, but just came up with "_Error: VM Exception while processing transaction: revert" we need to consider all these effects that could spawn this famous general error message.

This change will not affect any tests. In my case today many tests of openzeppelin-eth are still broken, but the (timed)crowdsale  based tests will not break  any more with this fix.

